### PR TITLE
Support servicebinding.io/v1beta1

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,1 +1,1 @@
-defaultBaseImage: cloudfoundry/run:tiny
+defaultBaseImage: gcr.io/paketo-buildpacks/run:tiny-cnb

--- a/README.md
+++ b/README.md
@@ -60,12 +60,12 @@ Samples are located in the [samples directory](./samples), including:
 
 ## Resources
 
-### ServiceBinding (servicebinding.io/v1alpha3)
+### ServiceBinding (servicebinding.io/v1beta1)
 
 The `ServiceBinding` resource shape and behavior is defined by the spec.
 
 ```
-apiVersion: servicebinding.io/v1alpha3
+apiVersion: servicebinding.io/v1beta1
 kind: ServiceBinding
 metadata:
   name: account-db

--- a/README.md
+++ b/README.md
@@ -7,19 +7,21 @@
 [![codecov](https://codecov.io/gh/vmware-labs/service-bindings/branch/main/graph/badge.svg)](https://codecov.io/gh/vmware-labs/service-bindings)
 
 
-Service Bindings for Kubernetes implements the [Service Binding Specification for Kubernetes](https://servicebinding.io/). We are tracking changes to the spec as it approaches a stable release (currently targeting [RC3](https://github.com/servicebinding/spec/tree/v1.0.0-rc3)). Backwards and forwards compatibility should not be expected for alpha versioned resources.
+Service Bindings for Kubernetes implements the [Service Binding Specification for Kubernetes](https://servicebinding.io/) v1.0.
 
 This implementation provides support for:
-- [Provisioned Service](https://github.com/servicebinding/spec/tree/v1.0.0-rc3#provisioned-service)
-- [Workload Projection](https://github.com/servicebinding/spec/tree/v1.0.0-rc3#workload-projection)
-- [Service Binding](https://github.com/servicebinding/spec/tree/v1.0.0-rc3#service-binding)
-- [Direct Secret Reference](https://github.com/servicebinding/spec/tree/v1.0.0-rc3#direct-secret-reference)
-- [Role-Based Access Control (RBAC)](https://github.com/servicebinding/spec/tree/v1.0.0-rc3#role-based-access-control-rbac)
+- [Provisioned Service](https://github.com/servicebinding/spec/tree/v1.0.0#provisioned-service)
+- [Workload Projection](https://github.com/servicebinding/spec/tree/v1.0.0#workload-projection)
+- [Service Binding](https://github.com/servicebinding/spec/tree/v1.0.0#service-binding)
+- [Direct Secret Reference](https://github.com/servicebinding/spec/tree/v1.0.0#direct-secret-reference)
+- [Role-Based Access Control (RBAC)](https://github.com/servicebinding/spec/tree/v1.0.0#role-based-access-control-rbac)
 
 The following are not implemented:
-- [Workload Resource Mapping](https://github.com/servicebinding/spec/tree/v1.0.0-rc3#workload-resource-mapping)
+- [Workload Resource Mapping](https://github.com/servicebinding/spec/tree/v1.0.0#workload-resource-mapping)
 - Extensions including:
-  - [Binding Secret Generation Strategies](https://github.com/servicebinding/spec/blob/v1.0.0-rc3/extensions/secret-generation.md)
+  - [Binding Secret Generation Strategies](https://github.com/servicebinding/spec/blob/v1.0.0/extensions/secret-generation.md)
+
+Equivalent capabilities from the v1.0.0-rc3 (servicebinding.io/v1alpha3) version of the spec are also supported. There are no significant API or runtime changes between v1alpha3 and v1beta1 versions.
 
 ## Try it out
 

--- a/config/300-servicebinding.yaml
+++ b/config/300-servicebinding.yaml
@@ -212,3 +212,192 @@ spec:
     storage: true
     subresources:
       status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].reason
+      name: Reason
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: ServiceBinding is the Schema for the servicebindings API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ServiceBindingSpec defines the desired state of ServiceBinding
+            properties:
+              env:
+                description: Env is the collection of mappings from Secret entries to environment variables
+                items:
+                  description: EnvMapping defines a mapping from the value of a Secret entry to an environment variable
+                  properties:
+                    key:
+                      description: Key is the key in the Secret that will be exposed
+                      type: string
+                    name:
+                      description: Name is the name of the environment variable
+                      type: string
+                  required:
+                  - key
+                  - name
+                  type: object
+                type: array
+              name:
+                description: Name is the name of the service as projected into the workload container.  Defaults to .metadata.name.
+                type: string
+              provider:
+                description: Provider is the provider of the service as projected into the workload container
+                type: string
+              service:
+                description: Service is a reference to an object that fulfills the ProvisionedService duck type
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                required:
+                - apiVersion
+                - kind
+                - name
+                type: object
+              type:
+                description: Type is the type of the service as projected into the workload container
+                type: string
+              workload:
+                description: Workload is a reference to an object
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  containers:
+                    description: Containers describes which containers in a Pod should be bound to
+                    items:
+                      type: string
+                    type: array
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  selector:
+                    description: Selector is a query that selects the workload or workloads to bind the service to
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector applies to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                required:
+                - apiVersion
+                - kind
+                type: object
+            required:
+            - service
+            - workload
+            type: object
+          status:
+            description: ServiceBindingStatus defines the observed state of ServiceBinding
+            properties:
+              binding:
+                description: Binding exposes the projected secret for this ServiceBinding
+                properties:
+                  name:
+                    description: 'Name of the referent secret. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                required:
+                - name
+                type: object
+              conditions:
+                description: Conditions are the conditions of this ServiceBinding
+                items:
+                  description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: ObservedGeneration is the 'Generation' of the ServiceBinding that was last processed by the controller.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}

--- a/samples/controlled-resource/service-binding.yaml
+++ b/samples/controlled-resource/service-binding.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-apiVersion: servicebinding.io/v1alpha3
+apiVersion: servicebinding.io/v1beta1
 kind: ServiceBinding
 metadata:
   name: controlled-resource

--- a/samples/multi-binding/service-binding.yaml
+++ b/samples/multi-binding/service-binding.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-apiVersion: servicebinding.io/v1alpha3
+apiVersion: servicebinding.io/v1beta1
 kind: ServiceBinding
 metadata:
   name: multi-binding-1
@@ -23,7 +23,7 @@ spec:
     key: number
 
 ---
-apiVersion: servicebinding.io/v1alpha3
+apiVersion: servicebinding.io/v1beta1
 kind: ServiceBinding
 metadata:
   name: multi-binding-2

--- a/samples/overridden-type-provider/service-binding.yaml
+++ b/samples/overridden-type-provider/service-binding.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-apiVersion: servicebinding.io/v1alpha3
+apiVersion: servicebinding.io/v1beta1
 kind: ServiceBinding
 metadata:
   name: overridden-type-provider

--- a/samples/provisioned-service/service-binding.yaml
+++ b/samples/provisioned-service/service-binding.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-apiVersion: servicebinding.io/v1alpha3
+apiVersion: servicebinding.io/v1beta1
 kind: ServiceBinding
 metadata:
   name: provisioned-service

--- a/samples/spring-petclinic/service-binding.yaml
+++ b/samples/spring-petclinic/service-binding.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-apiVersion: servicebinding.io/v1alpha3
+apiVersion: servicebinding.io/v1beta1
 kind: ServiceBinding
 metadata:
   name: spring-petclinic-db


### PR DESCRIPTION
The API is compatible with v1alpha3 and does not require a conversion
webhook. The controller and webhook still operate against v1alpha3, and
can be upgraded at some point in the future.

Signed-off-by: Scott Andrews <andrewssc@vmware.com>
