### PR TITLE
Resource pluralization for Postgres

### DIFF
--- a/pkg/resolver/serviceable_resolver.go
+++ b/pkg/resolver/serviceable_resolver.go
@@ -52,6 +52,11 @@ func (r *ServiceableResolver) ServiceableFromObjectReference(ctx context.Context
 		return nil, fmt.Errorf("failed to track %+v: %v", ref, err)
 	}
 	gvr, _ := meta.UnsafeGuessKindToResource(ref.GroupVersionKind())
+
+	// Tactical fix for Postgres resource pluralization
+	if gvr.Resource == "postgreses" && gvr.Group == "sql.tanzu.vmware.com" {
+		gvr.Resource = "postgres"
+	}
 	_, lister, err := r.informerFactory.Get(ctx, gvr)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Signed-off-by: Rashed Kamal <krashed@vmware.com>

Pull request
<!-- Please use this template and provide as much info as possible. Not doing so may delay the review of the pull request. Thanks!
-->

### What this PR does / why we need it
Tactical fix for `Postgres` resource pluralization. Correcting this bug using DynamicRestMapper requires major refactoring. We will clean up this implementation as we refactor this operator.

### Which issue(s) this PR fixes
<!--
     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first (and reference it here) so that the problem the PR addresses can be discussed independently of the solutions proposed by this PR. Usage: Fixes #<issue number>.
-->

Fixes #190 

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
Unit test for `pkg/resolver/serviceable_resolver_test.go` requires registering types. API group `sql.tanzu.vmware.com` is not public and did not register. Manual testing installing Tanzu Postgres Operator

### Additional information or special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->

