### PR TITLE
Switch petclinic image to ghcr

### DIFF
--- a/samples/spring-petclinic/workload.yaml
+++ b/samples/spring-petclinic/workload.yaml
@@ -33,7 +33,7 @@ spec:
       containers:
         - name: workload
           # built with paketo builder from https://github.com/spring-projects/spring-petclinic
-          image: scothis/petclinic:service-bindings-20200922
+          image: ghcr.io/vmware-tanzu/servicebinding/test/petclinic:20200922
           env:
           # tell the workload to use mysql instead of the default embedded database
           - name: SPRING_PROFILES_ACTIVE


### PR DESCRIPTION
The petclinic image was hosted on my personal dockerhub account. While
it is a "public" image, Docker Hub has started to require auth to pull.
Switching to GitHub Container Registry so that it's a repository under
the control of this project, and actually public.

Signed-off-by: Scott Andrews <andrewssc@vmware.com>
