### PR TITLE
chore: updated ko base image to run-jammy-static:0.0.28

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,6 +41,8 @@ jobs:
     - uses: actions/setup-go@v3
       with:
         go-version: 1.18.x
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - uses: vmware-tanzu/carvel-setup-action@v1
     - run: |
         imgpkg version
@@ -141,6 +143,8 @@ jobs:
     - uses: vmware-tanzu/carvel-setup-action@v1
       with:
         imgpkg: v0.29.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - run: |
         imgpkg version
         kbld version

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,2 +1,2 @@
-# paketobuildpacks/run-jammy-tiny:0.1.44
-defaultBaseImage: paketobuildpacks/run-jammy-tiny@sha256:c8b1ab2faa6d2f0b71813ebc08fca8688ad68989523e97046c52b65c283c2445
+# paketobuildpacks/run-jammy-static:0.0.28
+defaultBaseImage: paketobuildpacks/run-jammy-static@sha256:43f8f7f1b9181866221cc472719ddeca748dc95792a35b35a082935b50a554b7


### PR DESCRIPTION
Pull request
<!-- Please use this template and provide as much info as possible. Not doing so may delay the review of the pull request. Thanks!
-->

### What this PR does / why we need it
ko base image is updated to `run-jammy-static:0.0.28` that decreases package footprint

### Which issue(s) this PR fixes
<!--
     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first (and reference it here) so that the problem the PR addresses can be discussed independently of the solutions proposed by this PR. Usage: Fixes #<issue number>.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->


### Additional information or special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->

