### PR TITLE
chore: updated ko base image to run-jammy-static:0.0.49

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -133,6 +133,7 @@ jobs:
         - 1.24.2
         - 1.25.2
         - 1.26.0
+        - 1.27.0
       fail-fast: false
     env:
       REGISTRY_NAME: registry.local

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,2 +1,2 @@
-# paketobuildpacks/run-jammy-static:0.0.28
-defaultBaseImage: paketobuildpacks/run-jammy-static@sha256:43f8f7f1b9181866221cc472719ddeca748dc95792a35b35a082935b50a554b7
+# paketobuildpacks/run-jammy-static:0.0.49
+defaultBaseImage: paketobuildpacks/run-jammy-static@sha256:0cca9fb01b8a3512615f86420e5eef6958e483a4016bd60c0eff03fa74fbb645


### PR DESCRIPTION
Pull request
<!-- Please use this template and provide as much info as possible. Not doing so may delay the review of the pull request. Thanks!
-->

### What this PR does / why we need it
This request addresses:
1. update `.ko.yml` to use latest run-jammy-static image version `0.0.49`
2. Add kubernetes version `1.27` to CI test matrix.

### Which issue(s) this PR fixes
<!--
     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first (and reference it here) so that the problem the PR addresses can be discussed independently of the solutions proposed by this PR. Usage: Fixes #<issue number>.
-->

Fixes #

### Describe testing done for PR
https://github.com/vmware-tanzu/servicebinding/issues/281
<!-- Example: Created vSphere workload cluster to verify change. -->


### Additional information or special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->

