### PR TITLE
chore: Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -366,7 +366,7 @@ jobs:
     - name: Get release version
       id: get-version
       run: |
-        echo ::set-output name=version::$(cat VERSION)
+        echo "version=$(cat VERSION)" >> $GITHUB_OUTPUT
     - name: Draft release
       id: create_release
       uses: actions/create-release@v1.1.4


### PR DESCRIPTION
Pull request
<!-- Please use this template and provide as much info as possible. Not doing so may delay the review of the pull request. Thanks!
-->

### What this PR does / why we need it

Update `.github/workflows/ci.yaml` to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow file that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yaml
echo ::set-output name=version::$(cat VERSION)
```

**TO-BE**

```yaml
echo "version=$(cat VERSION)" >> $GITHUB_OUTPUT
```

### Which issue(s) this PR fixes
<!--
     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first (and reference it here) so that the problem the PR addresses can be discussed independently of the solutions proposed by this PR. Usage: Fixes #<issue number>.
-->

Fixes #286 

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
None

### Additional information or special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->
None

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->

