### PR TITLE
fix: Add Security context constrint for openshift

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -89,6 +89,7 @@ jobs:
         cp NOTICE "bundle/NOTICE"
         cp VERSION "bundle/VERSION"
         cp config/carvel/bundle.yaml "bundle/bundle.yaml"
+        cp config/carvel/bundle.yaml "bundle/openshift.yaml"
         cp -r samples "bundle/samples"
 
         echo "##[group]Build Service Bindings"

--- a/config/carvel/openshift.yaml
+++ b/config/carvel/openshift.yaml
@@ -1,0 +1,83 @@
+#@ load("@ytt:data", "data")
+
+#@  kubernetes_distribution = ""
+#@  if hasattr(data.values, 'kubernetes_distribution'):
+#@    kubernetes_distribution = data.values.kubernetes_distribution
+#@  end
+#@  if hasattr(data.values, 'shared') and hasattr(data.values.shared, 'kubernetes_distribution'):
+#@    kubernetes_distribution = data.values.shared.kubernetes_distribution
+#@  end
+
+#@  if kubernetes_distribution == "openshift":
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: service-binding-nonroot-scc
+  namespace: service-bindings
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - service-binding-scc
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: service-binding-nonroot-scc
+  namespace: service-bindings
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: service-binding-nonroot-scc
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:serviceaccounts:service-bindings
+---
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: false
+allowedCapabilities: null
+apiVersion: security.openshift.io/v1
+defaultAddCapabilities: null
+fsGroup:
+  type: MustRunAs
+groups: []
+kind: SecurityContextConstraints
+metadata:
+  name: service-binding-scc
+priority: null
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+- ALL
+runAsUser:
+  type: MustRunAsNonRoot
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+seccompProfiles:
+- runtime/default
+users: []
+volumes:
+- configMap
+- csi
+- downwardAPI
+- emptyDir
+- ephemeral
+- persistentVolumeClaim
+- projected
+- secret
+#@  end

--- a/config/carvel/openshift.yaml
+++ b/config/carvel/openshift.yaml
@@ -47,7 +47,7 @@ allowHostIPC: false
 allowHostNetwork: false
 allowHostPID: false
 allowHostPorts: false
-allowPrivilegeEscalation: true
+allowPrivilegeEscalation: false
 allowPrivilegedContainer: false
 allowedCapabilities: null
 apiVersion: security.openshift.io/v1

--- a/config/carvel/package-install.values.yaml
+++ b/config/carvel/package-install.values.yaml
@@ -13,3 +13,5 @@ service_account_name: service-binding-kc
 cluster_role_name: service-binding-kc
 cluster_role_binding_name: service-binding-kc
 sync_period: 10m
+shared:
+  kubernetes_distribution: null

--- a/config/carvel/package-install.yaml
+++ b/config/carvel/package-install.yaml
@@ -2,6 +2,25 @@
 #! SPDX-License-Identifier: Apache-2.0
 
 #@ load("@ytt:data", "data")
+#@ load("@ytt:base64", "base64")
+#@ load("@ytt:yaml", "yaml")
+
+#@ def collect_values():
+#@  values = {}
+#@  if hasattr(data.values, "shared"):
+#@    values["shared"] = data.values.shared
+#@  end
+#@  return values
+#@ end
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: service-bindings-values
+  namespace: #@ data.values.namespace
+stringData:
+  values.yaml: #@ yaml.encode(collect_values())
 
 ---
 apiVersion: packaging.carvel.dev/v1alpha1
@@ -22,6 +41,10 @@ spec:
       #@ if data.values.package_prerelease != None:
       prereleases: #@ data.values.package_prerelease
       #@ end
+  values:
+  - secretRef:
+      name: service-bindings-values
+
 
 ---
 apiVersion: kapp.k14s.io/v1alpha1

--- a/config/carvel/package.yaml
+++ b/config/carvel/package.yaml
@@ -25,5 +25,6 @@ spec:
           paths:
           - "-"
           - bundle.yaml
+          - openshift.yaml
       deploy:
       - kapp: {}


### PR DESCRIPTION
# Pull request

### What this PR does / why we need it

When adding the security context, the component fails to be installed in an openshift cluster due to it does not match any securitycontextconstraint

### Which issue(s) this PR fixes

Fixes N/A

### Describe testing done for PR

* Install TAP in a openshift cluster
* Apply the following file

<details><summary>Click to expand</summary>

  ```yaml
  #@ load("@ytt:data", "data")
  #@ load("@ytt:assert", "assert")
  ​
  #@ kubernetes_distribution = data.values.kubernetes_distribution
  #@ validDistributions = [None, "", "openshift"]
  #@ if kubernetes_distribution not in validDistributions:
  #@   assert.fail("{} not in {}".format(kubernetes_distribution, validDistributions))
  #@ end
  ​
  #@ if kubernetes_distribution == "openshift":
  ---
  apiVersion: rbac.authorization.k8s.io/v1
  kind: Role
  metadata:
    name: service-binding-nonroot-scc
    namespace: service-bindings
  rules:
  - apiGroups:
    - security.openshift.io
    resourceNames:
    - service-binding-scc
    resources:
    - securitycontextconstraints
    verbs:
    - use
    - get
    - list
    - watch
  ---
  apiVersion: rbac.authorization.k8s.io/v1
  kind: RoleBinding
  metadata:
    name: service-binding-nonroot-scc
    namespace: service-bindings
  roleRef:
    apiGroup: rbac.authorization.k8s.io
    kind: Role
    name: service-binding-nonroot-scc
  subjects:
  - apiGroup: rbac.authorization.k8s.io
    kind: Group
    name: system:serviceaccounts:service-bindings
  ---
  allowHostDirVolumePlugin: false
  allowHostIPC: false
  allowHostNetwork: false
  allowHostPID: false
  allowHostPorts: false
  allowPrivilegeEscalation: true
  allowPrivilegedContainer: false
  allowedCapabilities: null
  apiVersion: security.openshift.io/v1
  defaultAddCapabilities: null
  fsGroup:
    type: MustRunAs
  groups: []
  kind: SecurityContextConstraints
  metadata:
    name: service-binding-scc
  priority: null
  readOnlyRootFilesystem: false
  requiredDropCapabilities:
  - ALL
  runAsUser:
    type: MustRunAsNonRoot
  seLinuxContext:
    type: MustRunAs
  supplementalGroups:
    type: RunAsAny
  seccompProfiles:
  - runtime/default
  users: []
  volumes:
  - configMap
  - csi
  - downwardAPI
  - emptyDir
  - ephemeral
  - persistentVolumeClaim
  - projected
  - secret
  #@ end
  ```

</details>

* Check SB is up after deleting the deployment and kicking the SB app

### Additional information or special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->

